### PR TITLE
Update omniauth version constraints

### DIFF
--- a/omniauth-linear.gemspec
+++ b/omniauth-linear.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Linear::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5'
+  gem.add_dependency 'omniauth', '~> 2.0.0'
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_dependency 'graphql-client'
   gem.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
The current version of `omniauth` has a security [vulnerability](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) addressed in versions >2.

This PR merely updates the version constraints in the gemspec.